### PR TITLE
pc - DRY up HTML for Bootstrap

### DIFF
--- a/src/main/resources/templates/fragments/bootstrap_footer.html
+++ b/src/main/resources/templates/fragments/bootstrap_footer.html
@@ -1,0 +1,6 @@
+<!-- Footer -->
+<footer class="page-footer font-small secondary-color pt-4">
+    <p>
+        This sample template is available at <a href="https://github.com/pconrad-webapps/spring-boot-thymeleaf-bootstrap-from-cdn"></a>
+    </p>
+</footer>

--- a/src/main/resources/templates/fragments/bootstrap_head.html
+++ b/src/main/resources/templates/fragments/bootstrap_head.html
@@ -1,0 +1,5 @@
+<!-- fragments/bootstrap_head.html-->
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" /> 
+<link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css" integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous"></link>

--- a/src/main/resources/templates/fragments/bootstrap_nav_header.html
+++ b/src/main/resources/templates/fragments/bootstrap_nav_header.html
@@ -1,0 +1,15 @@
+<!-- fragments/bootstrap_nav_header.html-->
+<!-- See https://getbootstrap.com/docs/4.0/components/navbar/ for documentation on how to adjust HTML below -->
+<nav class="navbar navbar-expand-lg navbar-light bg-light">
+    <a class="navbar-brand" href="/">Sample-Website</a>
+    <!-- Button to collapse/expand navbar when it doesn't fit on the screen-->
+    <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarNavAltMarkup"
+        aria-controls="navbarNavAltMarkup" aria-expanded="false" aria-label="Toggle navigation">
+        <span class="navbar-toggler-icon"></span>
+    </button>
+    <div class="collapse navbar-collapse" id="navbarNavAltMarkup">
+        <div class="navbar-nav">
+            <a class="nav-item nav-link" href="/greeting">Greeting</a>
+        </div>
+    </div>
+</nav>

--- a/src/main/resources/templates/fragments/bootstrap_scripts.html
+++ b/src/main/resources/templates/fragments/bootstrap_scripts.html
@@ -1,0 +1,4 @@
+<!-- fragments/bootstrap_scripts.html-->
+<script src="https://code.jquery.com/jquery-3.3.1.slim.min.js" integrity="sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo" crossorigin="anonymous"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.7/umd/popper.min.js" integrity="sha384-UO2eT0CpHqdSJQ6hJty5KVphtPhzWj9WO1clHTMGa3JDZwrnQq4sF86dIHNDz0W1" crossorigin="anonymous"></script>
+<script src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js" integrity="sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM" crossorigin="anonymous"></script>

--- a/src/main/resources/templates/greeting.html
+++ b/src/main/resources/templates/greeting.html
@@ -1,11 +1,19 @@
 <!DOCTYPE HTML>
 <html xmlns:th="http://www.thymeleaf.org">
-  <head>
-    <title>Getting Started: Serving Web Content</title>
-    <div th:replace="fragments/bootstrap_head.html"></div>
-  </head>
-  <body>
-    <p th:text="'Hello, ' + ${name} + '!'" ></p>
-    <div th:replace="fragments/bootstrap_scripts.html"></div>
-  </body>
+
+<head>
+  <title>Getting Started: Serving Web Content</title>
+  <div th:replace="fragments/bootstrap_head.html"></div>
+</head>
+
+<body>
+  <div class="container">
+    <div th:replace="fragments/bootstrap_nav_header.html"></div>
+    <p th:text="'Hello, ' + ${name} + '!'"></p>
+    <div th:replace="fragments/bootstrap_footer.html"></div>
+  </div>
+
+  <div th:replace="fragments/bootstrap_scripts.html"></div>
+</body>
+
 </html>

--- a/src/main/resources/templates/greeting.html
+++ b/src/main/resources/templates/greeting.html
@@ -2,15 +2,10 @@
 <html xmlns:th="http://www.thymeleaf.org">
   <head>
     <title>Getting Started: Serving Web Content</title>
-    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-    <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
-    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css" integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous" />  
+    <div th:replace="fragments/bootstrap_head.html"></div>
   </head>
   <body>
     <p th:text="'Hello, ' + ${name} + '!'" ></p>
-    <script src="https://code.jquery.com/jquery-3.3.1.slim.min.js" integrity="sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo" crossorigin="anonymous"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.7/umd/popper.min.js" integrity="sha384-UO2eT0CpHqdSJQ6hJty5KVphtPhzWj9WO1clHTMGa3JDZwrnQq4sF86dIHNDz0W1" crossorigin="anonymous"></script>
-    <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js" integrity="sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM" crossorigin="anonymous"></script>
+    <div th:replace="fragments/bootstrap_scripts.html"></div>
   </body>
 </html>

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -2,18 +2,10 @@
 <html xmlns:th="http://www.thymeleaf.org" lang="en"> 
   <head>
     <title>Getting Started: Serving Web Content</title>
-  
-    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-    <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" /> 
-    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css" integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous"></link>
-    
+    <div th:replace="fragments/bootstrap_head.html"></div>
   </head>
   <body>
     <p>Get your greeting <a href="/greeting">here</a></p>
-
-    <script src="https://code.jquery.com/jquery-3.3.1.slim.min.js" integrity="sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo" crossorigin="anonymous"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.7/umd/popper.min.js" integrity="sha384-UO2eT0CpHqdSJQ6hJty5KVphtPhzWj9WO1clHTMGa3JDZwrnQq4sF86dIHNDz0W1" crossorigin="anonymous"></script>
-    <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js" integrity="sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM" crossorigin="anonymous"></script>
+    <div th:replace="fragments/bootstrap_scripts.html"></div>
   </body>
 </html>

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -1,11 +1,18 @@
 <!DOCTYPE HTML>
-<html xmlns:th="http://www.thymeleaf.org" lang="en"> 
-  <head>
-    <title>Getting Started: Serving Web Content</title>
-    <div th:replace="fragments/bootstrap_head.html"></div>
-  </head>
-  <body>
+<html xmlns:th="http://www.thymeleaf.org" lang="en">
+
+<head>
+  <title>Getting Started: Serving Web Content</title>
+  <div th:replace="fragments/bootstrap_head.html"></div>
+</head>
+
+<body>
+  <div class="container">
+    <div th:replace="fragments/bootstrap_nav_header.html"></div>
     <p>Get your greeting <a href="/greeting">here</a></p>
-    <div th:replace="fragments/bootstrap_scripts.html"></div>
-  </body>
+    <div th:replace="fragments/bootstrap_footer.html"></div>
+  </div>
+  <div th:replace="fragments/bootstrap_scripts.html"></div>
+</body>
+
 </html>

--- a/src/test/java/hello/GreetingControllerTest.java
+++ b/src/test/java/hello/GreetingControllerTest.java
@@ -52,4 +52,13 @@ public class GreetingControllerTest {
                 .andExpect(xpath("//title").string("Getting Started: Serving Web Content"));
     }
 
+    @Test
+    public void getGreeting_hasNavBar() throws Exception {
+        NavigationTestHelper.hasNavBar(mvc, "/greeting");
+    }
+
+    @Test
+    public void getGreeting_hasFooter() throws Exception {
+        NavigationTestHelper.hasFooter(mvc, "/greeting");
+    }
 }

--- a/src/test/java/hello/HomePageTest.java
+++ b/src/test/java/hello/HomePageTest.java
@@ -53,4 +53,14 @@ public class HomePageTest {
                 .andExpect(xpath("//title").exists())
                 .andExpect(xpath("//title").string("Getting Started: Serving Web Content"));
     }
+
+    @Test
+    public void getHomePage_hasNavBar() throws Exception {
+        NavigationTestHelper.hasNavBar(mvc, "/");
+    }
+
+    @Test
+    public void getHomePage_hasFooter() throws Exception {
+        NavigationTestHelper.hasFooter(mvc, "/");
+    }
 }

--- a/src/test/java/hello/NavigationTestHelper.java
+++ b/src/test/java/hello/NavigationTestHelper.java
@@ -1,0 +1,24 @@
+package hello;
+
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.xpath;
+
+public class NavigationTestHelper {
+
+    public static void hasNavBar(MockMvc mvc, String url) throws Exception  {
+        mvc.perform(MockMvcRequestBuilders.get(url).accept(MediaType.TEXT_HTML))
+        .andExpect(status().isOk())
+        .andExpect(xpath("//nav").exists());
+
+    }
+
+    public static void hasFooter(MockMvc mvc, String url) throws Exception  {
+        mvc.perform(MockMvcRequestBuilders.get(url).accept(MediaType.TEXT_HTML))
+        .andExpect(status().isOk())
+        .andExpect(xpath("//footer").exists());
+
+    }
+}


### PR DESCRIPTION
The previous version had copy/pasted code in two different templates.

In the new version, we use Thymeleaf's `th:replace` feature to pull the repeated code
from a `fragments` subdirectory of `templates`
